### PR TITLE
Update jems to latest. #4

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -27,7 +27,7 @@
       </value>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -27,17 +27,7 @@
       </value>
     </option>
   </component>
-  <component name="ProjectLevelVcsManager" settingsEditedManually="false">
-    <OptionsSetting value="true" id="Add" />
-    <OptionsSetting value="true" id="Remove" />
-    <OptionsSetting value="true" id="Checkout" />
-    <OptionsSetting value="true" id="Update" />
-    <OptionsSetting value="true" id="Status" />
-    <OptionsSetting value="true" id="Edit" />
-    <ConfirmationsSetting value="0" id="Add" />
-    <ConfirmationsSetting value="0" id="Remove" />
-  </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" default="true" assert-keyword="true" jdk-15="true" project-jdk-name="1.8 (1)" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -3,7 +3,9 @@
   <component name="ProjectModuleManager">
     <modules>
       <module fileurl="file://$PROJECT_DIR$/AndroidCarrotBindings.iml" filepath="$PROJECT_DIR$/AndroidCarrotBindings.iml" />
+      <module fileurl="file://$PROJECT_DIR$/androidcarrot.iml" filepath="$PROJECT_DIR$/androidcarrot.iml" />
       <module fileurl="file://$PROJECT_DIR$/androidcarrot/androidcarrot.iml" filepath="$PROJECT_DIR$/androidcarrot/androidcarrot.iml" />
+      <module fileurl="file://$PROJECT_DIR$/androidcarrot/androidcarrot-androidcarrot.iml" filepath="$PROJECT_DIR$/androidcarrot/androidcarrot-androidcarrot.iml" />
       <module fileurl="file://$PROJECT_DIR$/app/app.iml" filepath="$PROJECT_DIR$/app/app.iml" />
       <module fileurl="file://$PROJECT_DIR$/contentcarrot/contentcarrot.iml" filepath="$PROJECT_DIR$/contentcarrot/contentcarrot.iml" />
     </modules>

--- a/androidcarrot/build.gradle
+++ b/androidcarrot/build.gradle
@@ -22,12 +22,12 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:appcompat-v7:25.4.0'
+    compile 'com.android.support:appcompat-v7:' + SUPPORT_LIBRARY_VERSION
     compile('au.com.codeka:carrot:2.4.0') {
         exclude group: 'com.google.code.findbugs'
         exclude group: 'org.dmfs' // TODO remove when iterators has been removed from codeka:carrot
     }
-    compile 'org.dmfs:jems:1.13'
+    compile 'org.dmfs:jems:' + JEMS_VERSION
 
     testCompile 'junit:junit:4.12'
 }

--- a/androidcarrot/build.gradle
+++ b/androidcarrot/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.3"
+    buildToolsVersion '26.0.2'
 
     defaultConfig {
         minSdkVersion 9
@@ -22,9 +22,12 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:appcompat-v7:25.3.1'
-    compile('au.com.codeka:carrot:2.4.0',
-            { exclude group: 'com.google.code.findbugs' })
-    compile 'org.dmfs:iterators:1.7.1'
+    compile 'com.android.support:appcompat-v7:25.4.0'
+    compile('au.com.codeka:carrot:2.4.0') {
+        exclude group: 'com.google.code.findbugs'
+        exclude group: 'org.dmfs' // TODO remove when iterators has been removed from codeka:carrot
+    }
+    compile 'org.dmfs:jems:1.13'
+
     testCompile 'junit:junit:4.12'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -24,11 +24,15 @@ dependencies {
     androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    compile 'com.android.support:appcompat-v7:25.3.1'
+    compile 'com.android.support:appcompat-v7:25.4.0'
     compile 'com.android.support.constraint:constraint-layout:1.0.2'
     compile project(":androidcarrot")
     compile project(":contentcarrot")
-    compile 'com.github.dmfs.ContentPal:contactspal:-SNAPSHOT'
-    compile 'com.github.dmfs.ContentPal:contentpal:-SNAPSHOT'
+    compile('com.github.dmfs.ContentPal:contactspal:-SNAPSHOT') {
+        exclude group: 'org.dmfs'
+    }
+    compile ('com.github.dmfs.ContentPal:contentpal:-SNAPSHOT') {
+        exclude group: 'org.dmfs'
+    }
     testCompile 'junit:junit:4.12'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -24,15 +24,11 @@ dependencies {
     androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    compile 'com.android.support:appcompat-v7:25.4.0'
+    compile 'com.android.support:appcompat-v7:' + SUPPORT_LIBRARY_VERSION
     compile 'com.android.support.constraint:constraint-layout:1.0.2'
     compile project(":androidcarrot")
     compile project(":contentcarrot")
-    compile('com.github.dmfs.ContentPal:contactspal:-SNAPSHOT') {
-        exclude group: 'org.dmfs'
-    }
-    compile ('com.github.dmfs.ContentPal:contentpal:-SNAPSHOT') {
-        exclude group: 'org.dmfs'
-    }
+    compile 'com.github.dmfs.ContentPal:contactspal:' + CONTENTPAL_VERSION
+    compile 'com.github.dmfs.ContentPal:contentpal:' + CONTENTPAL_VERSION
     testCompile 'junit:junit:4.12'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.3"
+    buildToolsVersion '26.0.2'
     defaultConfig {
         applicationId "org.dmfs.android.carrot.demo"
         minSdkVersion 14

--- a/build.gradle
+++ b/build.gradle
@@ -3,9 +3,10 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -16,6 +17,7 @@ allprojects {
     repositories {
         jcenter()
         maven { url "https://jitpack.io" }
+        google()
     }
 }
 

--- a/contentcarrot/build.gradle
+++ b/contentcarrot/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.3"
+    buildToolsVersion '26.0.2'
 
     defaultConfig {
         minSdkVersion 14

--- a/contentcarrot/build.gradle
+++ b/contentcarrot/build.gradle
@@ -27,7 +27,9 @@ dependencies {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
     compile project(":androidcarrot")
-    compile 'com.github.dmfs.ContentPal:contentpal:-SNAPSHOT'
-    compile 'com.android.support:appcompat-v7:25.3.1'
+    compile ('com.github.dmfs.ContentPal:contentpal:-SNAPSHOT') {
+        exclude group: 'org.dmfs'
+    }
+    compile 'com.android.support:appcompat-v7:25.4.0'
     testCompile 'junit:junit:4.12'
 }

--- a/contentcarrot/build.gradle
+++ b/contentcarrot/build.gradle
@@ -27,9 +27,7 @@ dependencies {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
     compile project(":androidcarrot")
-    compile ('com.github.dmfs.ContentPal:contentpal:-SNAPSHOT') {
-        exclude group: 'org.dmfs'
-    }
-    compile 'com.android.support:appcompat-v7:25.4.0'
+    compile 'com.github.dmfs.ContentPal:contentpal:' + CONTENTPAL_VERSION
+    compile 'com.android.support:appcompat-v7:' + SUPPORT_LIBRARY_VERSION
     testCompile 'junit:junit:4.12'
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,3 +15,7 @@ org.gradle.jvmargs=-Xmx1536m
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
+# Dependency versions:
+CONTENTPAL_VERSION=-SNAPSHOT
+SUPPORT_LIBRARY_VERSION=25.4.0
+JEMS_VERSION=1.13

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,8 @@ org.gradle.jvmargs=-Xmx1536m
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
+
 # Dependency versions:
-CONTENTPAL_VERSION=-SNAPSHOT
 SUPPORT_LIBRARY_VERSION=25.4.0
 JEMS_VERSION=1.13
+CONTENTPAL_VERSION=fc8cca91

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip


### PR DESCRIPTION
It doesn't build at the moment because of:
```
Caused by: com.android.dex.DexException: Multiple dex files define Lorg/dmfs/optional/adapters/FirstPresent;
```

Most of the changes here are because after I couldn't fix the build, I though I update to latest gradle maybe that helps. But it didn't.
So `iterators` is excluded from codeka:carrot, and gradle dependencyInsight tells this as well, still during dexing the classes show up (it was ArrayIterable as well).