### PR TITLE
Update gradle dependency configs with new taxonomy. #6

### DIFF
--- a/androidcarrot/build.gradle
+++ b/androidcarrot/build.gradle
@@ -22,12 +22,13 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:appcompat-v7:' + SUPPORT_LIBRARY_VERSION
-    compile('au.com.codeka:carrot:2.4.0') {
+    api('au.com.codeka:carrot:2.4.0') {
         exclude group: 'com.google.code.findbugs'
         exclude group: 'org.dmfs' // TODO remove when iterators has been removed from codeka:carrot
     }
-    compile 'org.dmfs:jems:' + JEMS_VERSION
 
-    testCompile 'junit:junit:4.12'
+    implementation 'com.android.support:appcompat-v7:' + SUPPORT_LIBRARY_VERSION
+    implementation 'org.dmfs:jems:' + JEMS_VERSION
+
+    testImplementation 'junit:junit:4.12'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,15 +20,16 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
+    implementation project(":androidcarrot")
+    implementation project(":contentcarrot")
+    implementation 'com.android.support:appcompat-v7:' + SUPPORT_LIBRARY_VERSION
+    implementation 'com.android.support.constraint:constraint-layout:1.0.2'
+    implementation 'com.github.dmfs.ContentPal:contentpal:' + CONTENTPAL_VERSION
+    implementation 'com.github.dmfs.ContentPal:contactspal:' + CONTENTPAL_VERSION
+
+    testCompile 'junit:junit:4.12'
+
     androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    compile 'com.android.support:appcompat-v7:' + SUPPORT_LIBRARY_VERSION
-    compile 'com.android.support.constraint:constraint-layout:1.0.2'
-    compile project(":androidcarrot")
-    compile project(":contentcarrot")
-    compile 'com.github.dmfs.ContentPal:contactspal:' + CONTENTPAL_VERSION
-    compile 'com.github.dmfs.ContentPal:contentpal:' + CONTENTPAL_VERSION
-    testCompile 'junit:junit:4.12'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -27,9 +27,9 @@ dependencies {
     implementation 'com.github.dmfs.ContentPal:contentpal:' + CONTENTPAL_VERSION
     implementation 'com.github.dmfs.ContentPal:contactspal:' + CONTENTPAL_VERSION
 
-    testCompile 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.12'
 
-    androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
+    androidTestImplementation('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
 }

--- a/contentcarrot/build.gradle
+++ b/contentcarrot/build.gradle
@@ -22,12 +22,14 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
+    api project(":androidcarrot")
+
+    implementation 'com.android.support:appcompat-v7:' + SUPPORT_LIBRARY_VERSION
+    implementation 'com.github.dmfs.ContentPal:contentpal:' + CONTENTPAL_VERSION
+
+    testImplementation 'junit:junit:4.12'
+
+    androidTestImplementation('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    compile project(":androidcarrot")
-    compile 'com.github.dmfs.ContentPal:contentpal:' + CONTENTPAL_VERSION
-    compile 'com.android.support:appcompat-v7:' + SUPPORT_LIBRARY_VERSION
-    testCompile 'junit:junit:4.12'
 }


### PR DESCRIPTION
Implements #6.

As I understand from the guides `api` means transitively exposing the dependency further up, and `implementation` is just used in the module itself.
I suppose it may remove the need for those `exclude` statements as well if those are declared as `implementation` in the libraries itself.

I've built and run OpenTasks with this commit to try, everythink works.

(As a next step I would add 1.8 compatibility here and test again in OT. This lib comes handy now in testing these integrations with the new builds.)