### PR TITLE
Use Java 8 compatibility.

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -27,7 +27,7 @@
       </value>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/androidcarrot/build.gradle
+++ b/androidcarrot/build.gradle
@@ -19,6 +19,10 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
 }
 
 dependencies {

--- a/androidcarrot/src/main/java/org/dmfs/android/carrot/bindings/BundleBindings.java
+++ b/androidcarrot/src/main/java/org/dmfs/android/carrot/bindings/BundleBindings.java
@@ -3,7 +3,6 @@ package org.dmfs.android.carrot.bindings;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 
-import org.dmfs.iterators.Function;
 import org.dmfs.iterators.decorators.Mapped;
 
 import java.util.Iterator;
@@ -46,14 +45,7 @@ public final class BundleBindings implements Bindings, Iterable<EntryBindings>
     @Override
     public Iterator<EntryBindings> iterator()
     {
-        return new Mapped<>(mBundle.keySet().iterator(), new Function<String, EntryBindings>()
-        {
-            @Override
-            public EntryBindings apply(String argument)
-            {
-                return new EntryBindings(argument, decoratedValue(argument));
-            }
-        });
+        return new Mapped<>(mBundle.keySet().iterator(), key -> new EntryBindings(key, decoratedValue(key)));
     }
 
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,6 +17,10 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
 }
 
 dependencies {

--- a/contentcarrot/build.gradle
+++ b/contentcarrot/build.gradle
@@ -19,6 +19,10 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
 }
 
 dependencies {


### PR DESCRIPTION
This updates Java compatibility to 1.8 and replaces one anonymous class with lambda.

OpenTasks doesn't build with this version, that has to updated to 1.8 first.